### PR TITLE
Specify even parity in thermostat UART example

### DIFF
--- a/docs/user/configuration/thermostat.md
+++ b/docs/user/configuration/thermostat.md
@@ -12,6 +12,7 @@ uart:
     ...
   - id: ts_uart
     baud_rate: 2400  # may be 9600
+    parity: EVEN
     rx_pin:
       number: GPIO16
     tx_pin:


### PR DESCRIPTION
The validation prevents ESPHome from actually compiling without this, but we might as well reflect it in the documentation.