### PR TITLE
Update 0x42-unknown-hvac-options.md

### DIFF
--- a/docs/developer/it-protocol/0x62-get-response/0x42-unknown-hvac-options.md
+++ b/docs/developer/it-protocol/0x62-get-response/0x42-unknown-hvac-options.md
@@ -11,10 +11,14 @@ It cannot be set with the [`0x41` - Set Request](../0x41-set-request).
 | 0    | Command Type      | 0x42                |                                          |
 | 1    | Air Purifier      | 0x00 or 0x01        | Plasma Quad filter active or not         |
 | 2    | Night Mode        | 0x00 or 0x01        | Dims the LED status                      |
+| 3    | Circulator*       | 0x00 or 0x01        | In HEAT only. When target is reached outdoor unit stops and indoor continues FAN operation.|
+
+**might be same byte as the mode ECONO COOL? May be different functions on different units*
 
 
 ### Sample Packets
 
 ```
 [FC.62.01.30.10] 42.01.00.00.00.00.00.00.00.00.00.00.00.00.00.00 1A  // MSZ-AY35VGKP
+[FC.62.01.30.10] 42.01.01.01.00.00.00.00.00.00.00.00.00.00.00.00 18  // MSZ-LN25VG2W
 ```


### PR DESCRIPTION
Added circulator mode from my unit to the list.
This occupies the same button on the remote as ECONO COOL.
It might be that both functions are the same byte, but the unit itself performs different functions.
Needs to be tested by someone with a unit with the ECONO COOL function.