### PR TITLE
Fix swapped airflow control modes

### DIFF
--- a/docs/developer/it-protocol/0x41-set-request/0x08-set-run-state.md
+++ b/docs/developer/it-protocol/0x41-set-request/0x08-set-run-state.md
@@ -24,8 +24,8 @@ Seems to correlate (at least partially) with [`0x62 0x09` - Get Run State][get-r
 | Value | Name     |
 |-------|----------|
 | 0     | EVEN     |
-| 1     | DIRECT   |
-| 2     | INDIRECT |
+| 1     | INDIRECT |
+| 2     | DIRECT   |
 
 Confirmed to work on units with the i-See sensor and the DIRECTION key on the IR remote (e.g. MSZ-LN##VG#*).
 The mode can only be set when the horizontal vane field is set to 0x80 *and* the i-See sensor is activated on the unit.


### PR DESCRIPTION
Testing on my own MSZ-LN unit and cross referencing: https://github.com/echavet/MitsubishiCN105ESPHome/blob/e64743351e6d6b1eab5f2779eca0f4b51750aee1/components/cn105/Globals.h#L95 shows that INDIRECT is 1 and DIRECT is 2